### PR TITLE
joi schema fixed

### DIFF
--- a/controllers/itineraryController.js
+++ b/controllers/itineraryController.js
@@ -24,7 +24,7 @@ const validator = joi.object({
         .required() ,
     likes:
         joi.array()
-        .items(joi.hex())
+        .items(joi.string().hex())
         .required(),
     tags: 
         joi.array()


### PR DESCRIPTION
Logre hostear el back con render
[my-tinerary-back-juandream](https://my-tinerary-back-juandream.onrender.com)
Cambie esta linea que rompia todo, basicamente para usar joi.hex() hay que agregar .string() antes
La pagina con que hostee _render_ se actualiza también con cada cambio en la rama main de este repositorio, cuando se mergee se va a arreglar